### PR TITLE
Gdal x platform build

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -8,4 +8,6 @@ SQL_PASSWORD=dessert
 SQL_HOST=postgis
 SQL_PORT=5432
 DATABASE=postgres
+UBUNTU_BASE_IMAGE=ubuntu:latest
+PYTHON_VENV_PATH=/opt/venv
 

--- a/.env.prod
+++ b/.env.prod
@@ -8,3 +8,5 @@ SQL_PASSWORD=dessert
 SQL_HOST=geodjango_postgis_prod
 SQL_PORT=5432
 DATABASE=postgres
+UBUNTU_BASE_IMAGE=ubuntu:latest
+PYTHON_VENV_PATH=/opt/venv

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Basic operations dev
 
 down:
-	docker-compose down
+	docker compose down
 
 stop:
 	docker compose stop

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ The project makes use of some standard technologies:
 
 Currently adding `redis`.
 
+# Building
+
+Link the `.env` file to the appropriate environment file, e.g. `ln -s .env.dev .env`.
+
+Override UBUNTU_BASE_IMAGE in the `.env` file to use a different base image, e.g. `UBUNTU_BASE_IMAGE=arm64v8/ubuntu:latest`.
+
+Then run `make build` to build the project.
+
 # Goals
 
 I'd like to add

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,54 +1,59 @@
-FROM ubuntu:latest
+# Args from compose
+ARG UBUNTU_BASE_IMAGE=ubuntu:latest
+ARG PYTHON_VENV_PATH
+
+FROM ${UBUNTU_BASE_IMAGE}
 
 # Environmental Variables
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
-ENV GDAL_VERSION=3.4.1
-
-# set work directory
-WORKDIR /usr/src/app
-
-# Args
-
+# ENV GDAL_VERSION=3.4.1
 
 # Install the basics
 RUN apt-get update
 RUN apt-get install -y tzdata
-RUN apt-get clean && apt-get install -y python3-pip \
-    python3-pyproj \
+RUN apt-get clean && apt-get install -y \
     build-essential \
-    wget \
     ca-certificates \
-    postgresql \
-    postgresql-contrib \
-    postgis \
     vim \
+    wget \
     curl \
     zip \
     unzip \
-    netcat
+    python3-pip \
+    python3-pyproj \
+    python3-venv \
+    gdal-bin \
+    postgresql \
+    postgresql-contrib \
+    postgis
 
-# RUN pip install GDAL==3.2.2.1
-ADD requirements.txt /tmp/
+# Activate Python Virtual Environment
 
-# trying out GDAL fix
-# https://gis.stackexchange.com/questions/28966/python-gdal-package-missing-header-file-when-installing-via-pip
+ENV PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-"/opt/venv"}
+RUN python3 -m venv ${PYTHON_VENV_PATH}
+ENV PATH="${PYTHON_VENV_PATH}/bin:$PATH"
 
+# Install GDAL
 RUN apt-get install -y --install-recommends libgdal-dev
 RUN export CPLUS_INCLUDE_PATH=/usr/include/gdal
 RUN export C_INCLUDE_PATH=/usr/include/gdal
-RUN pip3 install gdal==3.4.1
-
+RUN pip install GDAL=="$(gdal-config --version).*"
 
 # Install PIP requirements
+ADD requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt
 
 # copy code over
 
-COPY . .
+# set work directory
+WORKDIR /usr/src/app
 
-# run entrypoint.sh
+COPY . .
+# COPY ./entrypoint.sh /usr/src/app/entrypoint.sh
+
 RUN chmod +x /usr/src/app/entrypoint.sh
+
 ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   webserver_python:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   webserver_python:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 
 services:
   webserver_python:
-    build: ./app
+    build:
+      context: ./app
+      args:
+        UBUNTU_BASE_IMAGE: ${UBUNTU_BASE_IMAGE}
+        PYTHON_VENV_PATH: ${PYTHON_VENV_PATH}
     container_name: geodjango_webserver_dev
     command: python3 hellodjango/manage.py runserver 0.0.0.0:8000
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     volumes:
       - geodjango_pg_data:/var/lib/postgresql
     restart: always
-  celery:
 
   redis:
     image: redis:7


### PR DESCRIPTION
Parameterize build to enable AMD64 and ARM64 Ubuntu base images (not fixed for prod)
Resolve GDAL install headaches;
Remove deprecated "version:" from docker-compose.yml;