### PR TITLE
chore: Clean up GST Dockerfile — remove PG server daemon, ubuntu:24.04, non-root user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,68 +1,60 @@
-
-ARG UBUNTU_BASE_IMAGE
+ARG UBUNTU_BASE_IMAGE=ubuntu:24.04
 FROM ${UBUNTU_BASE_IMAGE}
 
 ARG PYTHON_VENV_PATH=/opt/venv
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Environmental Variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 
-# assure TZ config
-RUN apt-get update && apt-get install -y tzdata
-
-# Install the basics, python utils, gdal, and postgres
-RUN apt-get install -y \
-    build-essential \
-    ca-certificates \
-    vim \
-    wget \
-    curl \
-    zip \
-    unzip \
-    python3-pip \
-    python3-pyproj \
-    python3-venv \
-    gdal-bin \
-    postgresql \
-    postgresql-contrib \
-    postgis \
-    netcat-traditional \
-    sqlite3 \
-    spatialite-bin \
-    libcairo2-dev \
-    libjpeg-dev \
-    libgif-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Python Installer Config
-COPY pip.conf /etc/pip.conf
-
-# Activate Python Virtual Environment
-RUN python3 -m venv ${PYTHON_VENV_PATH}
-ENV PATH="${PYTHON_VENV_PATH}/bin:$PATH"
-
-# Install GDAL python bindings
-RUN apt-get update \
-    && apt-get install -y --install-recommends libgdal-dev \
+# OS packages — geospatial toolchain + Python; no PostgreSQL server daemon
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        tzdata \
+        build-essential \
+        ca-certificates \
+        vim \
+        wget \
+        curl \
+        zip \
+        unzip \
+        python3-pip \
+        python3-pyproj \
+        python3-venv \
+        gdal-bin \
+        libgdal-dev \
+        libpq-dev \
+        postgis \
+        netcat-openbsd \
+        sqlite3 \
+        spatialite-bin \
+        libcairo2-dev \
+        libjpeg-dev \
+        libgif-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
-RUN pip install --trusted-host pypi.python.org --upgrade pip --default-timeout=1200 GDAL=="$(gdal-config --version).*" \
- && echo "succesfully built python gdal bindings"
 
-# Install PIP requirements
-ADD requirements.txt /tmp/
-RUN pip install --trusted-host pypi.python.org --default-timeout=1200 --upgrade pip -r /tmp/requirements.txt
+# Python virtual environment
+RUN python3 -m venv ${PYTHON_VENV_PATH}
+ENV PATH="${PYTHON_VENV_PATH}/bin:$PATH"
+
+# Install GDAL python bindings then project requirements
+RUN pip install --upgrade pip "GDAL==$(gdal-config --version).*"
+
+COPY requirements.txt /tmp/
+RUN pip install --default-timeout=1200 -r /tmp/requirements.txt
+
+# Non-root runtime user
+RUN useradd --create-home --shell /bin/bash appuser
 
 # Container entrypoint
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
 
-# set work directory
 WORKDIR /usr/src/app
+RUN chown appuser:appuser /usr/src/app
+USER appuser
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Closes #20.

Build infrastructure cleanup only — no application logic touched.

### What changed

- **Remove `postgresql` + `postgresql-contrib`** server daemon packages — GeoDjango only needs client libraries (`libpq-dev`), not a running PostgreSQL server inside the container
- **Base image**: `ubuntu:22.04` → `ubuntu:24.04` (Python 3.12, active LTS); `ARG UBUNTU_BASE_IMAGE=ubuntu:24.04` default added
- **`--no-install-recommends`** on all `apt-get install` calls
- **Consolidated apt layers**: two separate `apt-get` calls merged into one
- **Remove stale `pip.conf` COPY**: pip trusted-host config is redundant with modern pip; `--trusted-host` flags removed from pip commands
- **`ADD` → `COPY`** for `requirements.txt` (local file source)
- **Non-root user**: `appuser` created; `WORKDIR` chowned; `USER appuser` before `ENTRYPOINT`
- **`netcat-traditional` → `netcat-openbsd`**: package rename in ubuntu:24.04

### Geospatial dependencies kept (all intentional)

`postgis`, `libpq-dev`, `sqlite3`, `spatialite-bin`, `libgdal-dev`, `libcairo2-dev`, `libjpeg-dev`, `libgif-dev` — all required for GeoDjango and its geospatial toolchain.

## Test plan

- [ ] `docker build --no-cache -t gst-test docker/` succeeds with no errors
- [ ] `docker run --rm gst-test python3 -c "import django.contrib.gis; print('GeoDjango OK')"` passes
- [ ] `docker run --rm gst-test spatialite --version` succeeds
- [ ] `docker run --rm gst-test python3 -c "import cairo; print('Cairo OK')"` passes
- [ ] `docker run --rm gst-test whoami` returns `appuser` (not `root`)
- [ ] No `pg_lsclusters` output (server daemon absent)