### PR TITLE
fix(locations): unwrap plus4_code from spurious 1-tuple (#22)

### DIFF
--- a/app/hellodjango/locations/models/addresses.py
+++ b/app/hellodjango/locations/models/addresses.py
@@ -24,7 +24,7 @@ class United_States_Address(models.Model):
         max_length=2, null=True, blank=True, default=None
     )
     zip5 = models.CharField(max_length=5, null=True, blank=True, default=None)
-    plus4_code = (models.CharField(max_length=4, null=True, blank=True, default=None),)
+    plus4_code = models.CharField(max_length=4, null=True, blank=True, default=None)
     delivery_point = models.CharField(
         max_length=99, null=True, blank=True, default=None
     )


### PR DESCRIPTION
Closes #22.

## Summary

`models/addresses.py:27` had `plus4_code` defined as a 1-tuple containing a CharField:

```python
plus4_code = (models.CharField(max_length=4, null=True, blank=True, default=None),)
```

The trailing comma + parens made it a tuple rather than a model field. Django couldn't recognize it; the Meta class's index on `'plus4_code'` raised `FieldDoesNotExist` at app-load:

```
django.core.exceptions.FieldDoesNotExist: United_States_Address has no field named 'plus4_code'.
```

## Fix

One-character change. Remove the trailing comma + outer parens; matches the shape of every adjacent field in the same model:

```python
plus4_code = models.CharField(max_length=4, null=True, blank=True, default=None)
```

## Test plan

- [x] Visual inspection: matches surrounding field definitions.
- [ ] (Operator-side after merge) `python manage.py check` no longer raises FieldDoesNotExist for plus4_code.
- [ ] Downstream: siege-analytics/socialwarehouse bumps its submodule pin to this PR's merge commit; SW's CI gets past the plus4_code error to whatever's next.

## Verified-by

```
$ git diff app/hellodjango/locations/models/addresses.py
-    plus4_code = (models.CharField(max_length=4, null=True, blank=True, default=None),)
+    plus4_code = models.CharField(max_length=4, null=True, blank=True, default=None)
```

## Discovery context

Surfaced from `siege-analytics/socialwarehouse#62` -- SW added GST's `locations` app to INSTALLED_APPS via the submodule (SW PR #69), and Django's check step blew up on plus4_code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue with address data field handling that was preventing proper data storage and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/geodjango_simple_template/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->