### PR TITLE
fix(#31): settings/logging.py reads LOGS_DIRECTORY from sibling, not django.conf.settings

### DIFF
--- a/app/hellodjango/hellodjango/settings/logging.py
+++ b/app/hellodjango/hellodjango/settings/logging.py
@@ -1,31 +1,39 @@
 # python imports
 
+import logging
 import os
 from pathlib import Path
 
-#  django imports
+# read LOGS_DIRECTORY from the sibling path_settings module rather than
+# from django.conf.settings. settings/__init__.py star-imports path_settings
+# before this module loads, but django.conf.settings is a LazyObject that
+# is not populated until Django finishes its first Settings(settings_module)
+# boot. A cold star-import (test_settings doing `from .settings import *`)
+# runs this module INSIDE Settings.__init__ and raises AttributeError on
+# settings.LOGS_DIRECTORY. The sibling-module import resolves at compile
+# time and does not depend on Django's settings machinery.
 
-from django.conf import settings
+from .path_settings import LOGS_DIRECTORY
 
 # log file
 
 log_file_name = "django_application.log"
-Path(settings.LOGS_DIRECTORY).mkdir(parents=True, exist_ok=True)
-LOG_PATH = str(settings.LOGS_DIRECTORY / log_file_name)
+Path(LOGS_DIRECTORY).mkdir(parents=True, exist_ok=True)
+LOG_PATH = str(Path(LOGS_DIRECTORY) / log_file_name)
 
-# doing something very stupid here
+# touch the log file so the FileHandler does not fail on first write
 try:
-    Path(LOG_PATH).touch(exist_ok=True)  # will create file, if it exists will do nothing
+    Path(LOG_PATH).touch(exist_ok=True)
 except Exception as e:
-    message ="\n"
-    message +=f"Pathlib method to create the logging file didn't work, trying OS lib method:{e}"
+    message = "\n"
+    message += f"Pathlib method to create the logging file didn't work, trying OS lib method:{e}"
     logging.error(message)
 try:
     if not os.path.exists(LOG_PATH):
         f = open(LOG_PATH, 'w+').close()
 except Exception as e:
-    message ="\n"
-    message +=f"OS method to create the logging file didn't work, Alfred E. Neumann:{e}"
+    message = "\n"
+    message += f"OS method to create the logging file didn't work, Alfred E. Neumann:{e}"
     logging.error(message)
 
 


### PR DESCRIPTION
Closes #31.

`settings/logging.py` previously read `django.conf.settings.LOGS_DIRECTORY`. That works inside docker where Django boots once and the proxy is populated by the time anything touches it, but it breaks during cold star-imports (e.g. a hand-rolled `test_settings.py` doing `from .settings import *`) — the chain runs inside `Settings.__init__` before any value is reachable via `django.conf.settings`.

Switched to `from .path_settings import LOGS_DIRECTORY`. The settings package's own module graph is the authoritative source while the package is still loading; `django.conf.settings` is the right surface for code that runs after Django boots.

Also added `import logging` (the existing `logging.error(...)` calls in the fallback branches referenced a name that wasn't actually imported).

## Acceptance

```bash
python -c "
import os
os.environ['DJANGO_SETTINGS_MODULE'] = 'hellodjango.settings'
from hellodjango.settings import LOGGING
print('LOGGING ok:', bool(LOGGING))
"
```

The cold-import repro from the issue body should no longer raise `AttributeError: 'Settings' object has no attribute 'LOGS_DIRECTORY'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging system reliability by fixing configuration initialization issues that could have affected application startup and log file creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->